### PR TITLE
Use StandardMethodCodec to pass results from platforms into Flutter.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }
 }
 
@@ -24,7 +23,6 @@ allprojects {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlinx-serialization'
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -53,7 +51,6 @@ android {
 
     dependencies {
         implementation 'net.java.dev.jna:jna:5.13.0@aar'
-        implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'
     }

--- a/android/src/main/kotlin/com/example/mopro_flutter/MoproFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/example/mopro_flutter/MoproFlutterPlugin.kt
@@ -1,7 +1,5 @@
 package com.example.mopro_flutter
 
-import androidx.annotation.NonNull
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -10,70 +8,75 @@ import io.flutter.plugin.common.MethodChannel.Result
 
 import uniffi.mopro.generateCircomProof
 
-import org.json.JSONObject
-import android.util.Log
-import io.flutter.plugin.common.JSONMethodCodec
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import uniffi.mopro.GenerateProofResult
+import io.flutter.plugin.common.StandardMethodCodec
+import uniffi.mopro.ProofCalldata
 import uniffi.mopro.toEthereumInputs
 import uniffi.mopro.toEthereumProof
 
 /** MoproFlutterPlugin */
-class MoproFlutterPlugin: FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private lateinit var channel : MethodChannel
+class MoproFlutterPlugin : FlutterPlugin, MethodCallHandler {
+    /// The MethodChannel that will the communication between Flutter and native Android
+    ///
+    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+    /// when the Flutter Engine is detached from the Activity
+    private lateinit var channel: MethodChannel
 
-  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "mopro_flutter", JSONMethodCodec.INSTANCE)
-    channel.setMethodCallHandler(this)
-  }
-
-  fun JSONObject.toMap(): Map<String, List<String>> {
-    val map = mutableMapOf<String, List<String>>()
-    this.keys().forEach { key ->
-      val list = mutableListOf<String>()
-      val jsonArray = this.getJSONArray(key)
-      for (i in 0 until jsonArray.length()) {
-        list.add(jsonArray.getString(i))
-      }
-      map[key] = list
-    }
-    return map
-  }
-
-  override fun onMethodCall(call: MethodCall, result: Result) {
-    if (call.method == "generateProof") {
-      val zkeyPath = call.argument<String>("zkeyPath") ?: return result.error("ARGUMENT_ERROR", "Missing zkeyPath", null)
-
-      val inputsJson = call.argument<JSONObject>("inputs") ?: return result.error("ARGUMENT_ERROR", "Missing inputs", null)
-      val inputs = inputsJson.toMap() as Map<String, List<String>>
- 
-      val res: GenerateProofResult = generateCircomProof(zkeyPath, inputs)
-      val proof = toEthereumProof(res.proof)
-      val convertedInputs = toEthereumInputs(res.inputs)
-      
-      Log.d("generateProof", "$res")
-
-        // Build the JSON response
-        val json = JSONObject().apply {
-            put("proof", Json.encodeToString(proof))
-            put("inputs", Json.encodeToString(convertedInputs))
-        }
-
-        // Send the JSON string back to Flutter
-        result.success(
-          json
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        channel = MethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            "mopro_flutter",
+            StandardMethodCodec.INSTANCE
         )
-    } else {
-      result.notImplemented()
+        channel.setMethodCallHandler(this)
     }
-  }
 
-  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    channel.setMethodCallHandler(null)
-  }
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        if (call.method == "generateProof") {
+            val zkeyPath = call.argument<String>("zkeyPath") ?: return result.error(
+                "ARGUMENT_ERROR",
+                "Missing zkeyPath",
+                null
+            )
+
+            val inputs =
+                call.argument<HashMap<String, List<String>>>("inputs") ?: return result.error(
+                    "ARGUMENT_ERROR",
+                    "Missing inputs",
+                    null
+                )
+
+            val res = generateCircomProof(zkeyPath, inputs)
+            val proof: ProofCalldata = toEthereumProof(res.proof)
+            val convertedInputs: List<String> = toEthereumInputs(res.inputs)
+
+            val proofList = listOf(
+                mapOf(
+                    "x" to proof.a.x,
+                    "y" to proof.a.y
+                ), mapOf(
+                    "x" to proof.b.x,
+                    "y" to proof.b.y
+                ), mapOf(
+                    "x" to proof.c.x,
+                    "y" to proof.c.y
+                )
+            )
+
+            // Return the proof and inputs as a map supported by the StandardMethodCodec
+            val resMap = mapOf(
+                "proof" to proofList,
+                "inputs" to convertedInputs
+            )
+
+            result.success(
+                resMap
+            )
+        } else {
+            result.notImplemented()
+        }
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
 }

--- a/android/src/main/kotlin/uniffi/mopro/mopro.kt
+++ b/android/src/main/kotlin/uniffi/mopro/mopro.kt
@@ -23,7 +23,6 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
 import com.sun.jna.ptr.*
-import kotlinx.serialization.Serializable
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.CharBuffer
@@ -1176,7 +1175,6 @@ public object FfiConverterByteArray : FfiConverterRustBuffer<ByteArray> {
     }
 }
 
-@Serializable
 data class G1(
     var `x`: kotlin.String,
     var `y`: kotlin.String,
@@ -1206,7 +1204,6 @@ public object FfiConverterTypeG1 : FfiConverterRustBuffer<G1> {
     }
 }
 
-@Serializable
 data class G2(
     var `x`: List<kotlin.String>,
     var `y`: List<kotlin.String>,
@@ -1265,7 +1262,6 @@ public object FfiConverterTypeGenerateProofResult : FfiConverterRustBuffer<Gener
     }
 }
 
-@Serializable
 data class ProofCalldata(
     var `a`: G1,
     var `b`: G2,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:mopro_flutter/mopro_flutter.dart';
+import 'package:mopro_flutter/mopro_types.dart';
 
 void main() {
   runApp(const MyApp());
@@ -95,7 +96,7 @@ class _MyAppState extends State<MyApp> {
                           });
 
                           FocusManager.instance.primaryFocus?.unfocus();
-                          Map<String, dynamic>? proofResult;
+                          GenerateProofResult? proofResult;
                           PlatformException? error;
                           // Platform messages may fail, so we use a try/catch PlatformException.
                           // We also handle the message potentially returning null.
@@ -121,10 +122,7 @@ class _MyAppState extends State<MyApp> {
                           if (!mounted) return;
 
                           setState(() {
-                            _proofResult = proofResult == null
-                                ? null
-                                : GenerateProofResult(proofResult["proof"],
-                                    proofResult["inputs"]);
+                            _proofResult = proofResult;
                             _error = error;
                           });
                         },

--- a/ios/Classes/MoproFlutterPlugin.swift
+++ b/ios/Classes/MoproFlutterPlugin.swift
@@ -4,7 +4,7 @@ import UIKit
 
 public class MoproFlutterPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let channel = FlutterMethodChannel(name: "mopro_flutter", binaryMessenger: registrar.messenger(), codec: FlutterJSONMethodCodec())
+        let channel = FlutterMethodChannel(name: "mopro_flutter", binaryMessenger: registrar.messenger())
         let instance = MoproFlutterPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
@@ -25,21 +25,20 @@ public class MoproFlutterPlugin: NSObject, FlutterPlugin {
                 let proofResult = try generateCircomProof(zkeyPath: zkeyPath, circuitInputs: inputs)
                 let proof = toEthereumProof(proof: proofResult.proof)
                 let convertedInputs = toEthereumInputs(inputs: proofResult.inputs)
-                let proofJson = try JSONEncoder().encode(proof)
-                let inputsJson = try JSONEncoder().encode(convertedInputs)
-
-                if let proofString = String(data: proofJson, encoding: .utf8), let inputsString = String(data: inputsJson, encoding: .utf8) {
-                    let response: [String: String] = [
-                        "proof": proofString,
-                        "inputs": inputsString
-                    ]
-                    result(response)
-                } else {
-                    result(FlutterError(code: "PROOF_GENERATION_ERROR", message: "Failed to convert proof to a string.", details: nil))
-                }
-
-                // Return the response to Flutter
-
+               
+                let proofList: [[String: Any]] = [
+                    ["x": proof.a.x, "y": proof.a.y],
+                    ["x": proof.b.x, "y": proof.b.y],
+                    ["x": proof.c.x, "y": proof.c.y]
+                ]
+                
+                let resMap: [String: Any] = [
+                    "proof": proofList,
+                    "inputs": convertedInputs
+                ]
+                
+                // Return the proof and inputs as a map supported by the StandardMethodCodec
+                result(resMap)
             } catch {
                 result(FlutterError(code: "PROOF_GENERATION_ERROR", message: "Failed to generate proof", details: error.localizedDescription))
             }

--- a/ios/Classes/mopro.swift
+++ b/ios/Classes/mopro.swift
@@ -455,7 +455,7 @@ private struct FfiConverterData: FfiConverterRustBuffer {
     }
 }
 
-public struct G1: Codable {
+public struct G1 {
     public var x: String
     public var y: String
 
@@ -507,7 +507,7 @@ public func FfiConverterTypeG1_lower(_ value: G1) -> RustBuffer {
     return FfiConverterTypeG1.lower(value)
 }
 
-public struct G2: Codable {
+public struct G2 {
     public var x: [String]
     public var y: [String]
 
@@ -611,7 +611,7 @@ public func FfiConverterTypeGenerateProofResult_lower(_ value: GenerateProofResu
     return FfiConverterTypeGenerateProofResult.lower(value)
 }
 
-public struct ProofCalldata: Codable {
+public struct ProofCalldata {
     public var a: G1
     public var b: G2
     public var c: G1

--- a/lib/mopro_flutter.dart
+++ b/lib/mopro_flutter.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:mopro_flutter/mopro_types.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'mopro_flutter_platform_interface.dart';
@@ -9,10 +10,8 @@ class MoproFlutter {
   Future<String> copyAssetToFileSystem(String assetPath) async {
     // Load the asset as bytes
     final byteData = await rootBundle.load(assetPath);
-    print("key size: ${byteData.lengthInBytes}");
     // Get the app's document directory (or other accessible directory)
     final directory = await getApplicationDocumentsDirectory();
-    print("directory: ${directory.path}");
     //Strip off the initial dirs from the filename
     assetPath = assetPath.split('/').last;
 
@@ -24,17 +23,10 @@ class MoproFlutter {
     return file.path; // Return the file path
   }
 
-  Future<Map<String, dynamic>?> generateProof(
+  Future<GenerateProofResult?> generateProof(
       String zkeyFile, Map<String, List<String>> inputs) async {
     return await copyAssetToFileSystem(zkeyFile).then((path) async {
       return await MoproFlutterPlatform.instance.generateProof(path, inputs);
     });
   }
-}
-
-class GenerateProofResult {
-  final String proof;
-  final String inputs;
-
-  GenerateProofResult(this.proof, this.inputs);
 }

--- a/lib/mopro_flutter_method_channel.dart
+++ b/lib/mopro_flutter_method_channel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:mopro_flutter/mopro_types.dart';
 
 import 'mopro_flutter_platform_interface.dart';
 
@@ -7,17 +8,23 @@ import 'mopro_flutter_platform_interface.dart';
 class MethodChannelMoproFlutter extends MoproFlutterPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  final methodChannel = const MethodChannel('mopro_flutter', JSONMethodCodec());
+  final methodChannel = const MethodChannel('mopro_flutter');
 
   @override
-  Future<Map<String, dynamic>?> generateProof(
+  Future<GenerateProofResult?> generateProof(
       String zkeyPath, Map<String, List<String>> inputs) async {
     final proofResult = await methodChannel
-        .invokeMethod<Map<String, dynamic>>('generateProof', {
+        .invokeMethod<Map<Object?, Object?>>('generateProof', {
       'zkeyPath': zkeyPath,
       'inputs': inputs,
     });
-    print("proofResult: $proofResult");
-    return proofResult;
+
+    if (proofResult == null) {
+      return null;
+    }
+
+    var generateProofResult = GenerateProofResult.fromMap(proofResult);
+
+    return generateProofResult;
   }
 }

--- a/lib/mopro_flutter_platform_interface.dart
+++ b/lib/mopro_flutter_platform_interface.dart
@@ -1,5 +1,4 @@
-import 'package:flutter/services.dart';
-import 'package:mopro_flutter/mopro_flutter.dart';
+import 'package:mopro_flutter/mopro_types.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'mopro_flutter_method_channel.dart';
@@ -25,7 +24,7 @@ abstract class MoproFlutterPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<Map<String, dynamic>?> generateProof(
+  Future<GenerateProofResult?> generateProof(
       String zkeyPath, Map<String, List<String>> inputs) {
     throw UnimplementedError('generateProof() has not been implemented.');
   }

--- a/lib/mopro_types.dart
+++ b/lib/mopro_types.dart
@@ -1,0 +1,54 @@
+class G1Point {
+  final String x;
+  final String y;
+
+  G1Point(this.x, this.y);
+
+  @override
+  String toString() {
+    return "G1Point(\nx: $x, \ny: $y)";
+  }
+}
+
+class G2Point {
+  final List<String> x;
+  final List<String> y;
+
+  G2Point(this.x, this.y);
+
+  @override
+  String toString() {
+    return "G2Point(\nx: $x, \ny: $y)";
+  }
+}
+
+class ProofCalldata {
+  final G1Point a;
+  final G2Point b;
+  final G1Point c;
+
+  ProofCalldata(this.a, this.b, this.c);
+
+  @override
+  String toString() {
+    return "ProofCalldata(\na: $a, \nb: $b, \nc: $c)";
+  }
+}
+
+class GenerateProofResult {
+  final ProofCalldata proof;
+  final List<String> inputs;
+
+  GenerateProofResult(this.proof, this.inputs);
+
+  factory GenerateProofResult.fromMap(Map<Object?, Object?> proofResult) {
+    var proof = proofResult["proof"] as List;
+    var inputs = proofResult["inputs"] as List;
+    return GenerateProofResult(
+        ProofCalldata(
+            G1Point(proof[0]["x"] as String, proof[0]["y"] as String),
+            G2Point(proof[1]["x"].cast<String>(), proof[1]["y"].cast<String>()),
+            G1Point(proof[2]["x"] as String, proof[2]["y"] as String)),
+        inputs.cast<String>());
+  }
+}


### PR DESCRIPTION
Remove serialization-related code from platform-specific code.