### PR TITLE
ci: add Flutter template CI tests

### DIFF
--- a/.github/workflows/flutter-template-ci.yml
+++ b/.github/workflows/flutter-template-ci.yml
@@ -1,0 +1,30 @@
+name: Flutter Template CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Flutter plugin
+        run: flutter build apk --debug
+
+      - name: Run unit tests
+        run: flutter test
+
+      - name: Run integration tests
+        run: flutter test integration_test/plugin_integration_test.dart


### PR DESCRIPTION
This PR adds CI tests to the Flutter template repo.

CI runs:
- `flutter pub get`
-` flutter build apk`
- flutter test
- flutter test `integration_test/plugin_integration_test.dart`
This follows same flows as CI for `circom`, halo2, and noir templates in `MoPro` CLI repo.

Following #576 of https://github.com/zkmopro/mopro/issues/571#event-20079994488
